### PR TITLE
Fixes #2: Improve map functionality to load more stops on pan and zoom

### DIFF
--- a/src/components/map/GoogleMap.svelte
+++ b/src/components/map/GoogleMap.svelte
@@ -3,8 +3,8 @@
   import {
     PUBLIC_OBA_GOOGLE_MAPS_API_KEY as apiKey,
     PUBLIC_OBA_GOOGLE_MAPS_MAP_ID as mapID,
-    PUBLIC_OBA_REGION_CENTER_LAT as lat,
-    PUBLIC_OBA_REGION_CENTER_LNG as lng
+    PUBLIC_OBA_REGION_CENTER_LAT as initialLat,
+    PUBLIC_OBA_REGION_CENTER_LNG as initialLng
   } from '$env/static/public';
 
   import {
@@ -12,11 +12,13 @@
     loadGoogleMapsLibrary
   } from "$lib/googleMaps";
 
-  import busIcon from "$images/modes/bus.svg"
+  import busIcon from "$images/modes/bus.svg";
 
   const dispatch = createEventDispatcher();
 
   let map = null;
+
+  let markers = [];
 
   async function loadStopsForLocation(lat, lng) {
     const response = await fetch(`/api/oba/stops-for-location?lat=${lat}&lng=${lng}`);
@@ -27,29 +29,64 @@
   }
 
   async function initMap() {
-    const { AdvancedMarkerElement, PinElement } = await google.maps.importLibrary("marker");
     const element = document.getElementById("map");
-    map = await createMap({element, lat, lng, mapID});
+    map = await createMap({ element, lat: initialLat, lng: initialLng, mapID });
+
+    await loadStopsAndAddMarkers(initialLat, initialLng);
+
+    const debouncedLoadMarkers = debounce(async () => {
+      const center = map.getCenter();
+      await loadStopsAndAddMarkers(center.lat(), center.lng());
+    }, 300);
+
+    map.addListener('dragend', debouncedLoadMarkers);
+    map.addListener('zoom_changed', debouncedLoadMarkers);
+  }
+
+  async function loadStopsAndAddMarkers(lat, lng) {
+    const { AdvancedMarkerElement, PinElement } = await google.maps.importLibrary("marker");
 
     const json = await loadStopsForLocation(lat, lng);
     const stops = json.data.list;
 
     for (const s of stops) {
-      const glyphImg = document.createElement("img");
-      glyphImg.src = busIcon;
-      const glyphSvgPinElement = new PinElement({glyph: glyphImg});
-
-      const marker = new AdvancedMarkerElement({
-        map: map,
-        position: {lat: s.lat, lng: s.lon},
-        title: s.name,
-        content: glyphSvgPinElement.element,
-      });
-
-      marker.addListener('click', () => {
-        dispatch('stopSelected', { stop: s });
-      });
+      if (!markerExists(s)) {
+        addMarker(s, AdvancedMarkerElement, PinElement);
+      }
     }
+  }
+
+  function markerExists(s) {
+    return markers.some(marker => marker.s.id === s.id);
+  }
+
+  function addMarker(s, AdvancedMarkerElement, PinElement) {
+    const glyphImg = document.createElement("img");
+    glyphImg.src = busIcon;
+
+    const glyphSvgPinElement = new PinElement({ glyph: glyphImg });
+
+    const marker = new AdvancedMarkerElement({
+      map,
+      position: { lat: s.lat, lng: s.lon },
+      title: s.name,
+      content: glyphSvgPinElement.element,
+    });
+
+    marker.addListener('click', () => {
+      dispatch('stopSelected', { stop: s });
+    });
+
+    markers.push({ s, marker });
+  }
+
+  function debounce(func, wait) {
+    let timeout;
+
+    return function(...args) {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => func.apply(this, args), wait);
+    };
   }
 
   onMount(async () => {


### PR DESCRIPTION
Fixed #2 

**Tasks done:**

- Added a debounce function to ensure the loadStopsAndAddMarkers function is not called more frequently than once every 300 milliseconds.
- The loadStopsAndAddMarkers function fetches stops for the current center of the map and adds markers after checking for duplicates.
- The markerExists function checks if a marker for a specific stop ID already exists.

**Screenshot:**
![bandicam2024-06-2611-01-36-299-ezgif com-video-to-gif-converter](https://github.com/OneBusAway/onebusaway-webapp/assets/62840625/829388a0-7249-4fbd-bdfe-745b7b5ef7c2)
