### PR TITLE
Changed the Region Name text to OBA Logo

### DIFF
--- a/src/components/navigation/Header.svelte
+++ b/src/components/navigation/Header.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { PUBLIC_OBA_REGION_NAME } from '$env/static/public';
+	import { PUBLIC_OBA_REGION_NAME, PUBLIC_OBA_LOGO_URL } from '$env/static/public';
 	import ThemeSwitcher from '$lib/ThemeSwitch/ThemeSwitcher.svelte';
 </script>
 
@@ -7,7 +7,9 @@
 	class="bg-blur-md flex items-center justify-between border-b border-neutral-300 bg-white/80 px-4 dark:bg-black dark:text-white"
 >
 	<div class="px-2 py-2">
-		<h1 class="text-3xl font-semibold">{PUBLIC_OBA_REGION_NAME}</h1>
+		<a href="/">
+			<img src={PUBLIC_OBA_LOGO_URL} alt={PUBLIC_OBA_REGION_NAME} class="h-10 rounded-sm" />
+		</a>
 	</div>
 	<div>
 		<ThemeSwitcher />


### PR DESCRIPTION
Fixes #20 

**Tasks done:**

- Added the logo in the navbar (with some roundness for better UI)
- The logo URL is added in the .env file (currently using the imgur for uploading the logo to get the URL).
The logo is wrapped in a hyperlink that navigates back to the root path and use the value of PUBLIC_OBA_REGION_NAME for its alt attribute.

![image](https://github.com/user-attachments/assets/ddae4870-3061-44d0-bcb8-061b1a50b4c0)
