### PR TITLE
fix: added the url pushstate when search for a stop/route

### DIFF
--- a/src/components/map/GoogleMap.svelte
+++ b/src/components/map/GoogleMap.svelte
@@ -93,6 +93,7 @@
 		// show the same stop twice on the map
 		if (stop.id != selectedStopID) {
 			addMarker(stop);
+			pushState(`/stops/${stop.id}`);
 			map.setCenter({ lat: stop.lat, lng: stop.lon });
 		}
 	}


### PR DESCRIPTION
## What was the issue?
Currently, when a user searches for a stop, the URL doesn't change according to the searched selected stop.

## Changes Done:

Now, the URL changes when the user searches for a stop or route.