### PR TITLE
Search Box UI Fixes

### DIFF
--- a/src/components/search/SearchField.svelte
+++ b/src/components/search/SearchField.svelte
@@ -24,11 +24,11 @@
 
 <div>
 	<label for="search" class="sr-only">Search</label>
-	<div class="flex mt-2 rounded-md shadow-sm">
-		<div class="focus-within:z-10 relative flex items-stretch flex-grow">
-			<div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+	<div class="mt-2 flex rounded-md shadow-sm">
+		<div class="relative flex flex-grow items-stretch focus-within:z-10">
+			<div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
 				<svg
-					class="dark:text-gray-400 w-4 h-4 text-gray-500"
+					class="h-4 w-4 text-gray-500 dark:text-gray-400"
 					aria-hidden="true"
 					xmlns="http://www.w3.org/2000/svg"
 					fill="none"
@@ -56,7 +56,7 @@
 		<button
 			type="button"
 			on:click={onHandleSearch}
-			class="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-300 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:hover:text-gray-900"
+			class="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-gray-900"
 		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/src/components/search/SearchField.svelte
+++ b/src/components/search/SearchField.svelte
@@ -24,11 +24,11 @@
 
 <div>
 	<label for="search" class="sr-only">Search</label>
-	<div class="mt-2 flex rounded-md shadow-sm">
-		<div class="relative flex flex-grow items-stretch focus-within:z-10">
-			<div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+	<div class="flex mt-2 rounded-md shadow-sm">
+		<div class="focus-within:z-10 relative flex items-stretch flex-grow">
+			<div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
 				<svg
-					class="h-4 w-4 text-gray-500 dark:text-gray-400"
+					class="dark:text-gray-400 w-4 h-4 text-gray-500"
 					aria-hidden="true"
 					xmlns="http://www.w3.org/2000/svg"
 					fill="none"
@@ -56,7 +56,7 @@
 		<button
 			type="button"
 			on:click={onHandleSearch}
-			class="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+			class="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-300 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:hover:text-gray-900"
 		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -102,15 +102,15 @@
 </script>
 
 <div
-	class="bg-blur-sm flex w-96 justify-between rounded-lg border-gray-500 bg-white/90 px-4 shadow-lg dark:bg-black dark:text-white"
+	class="bg-blur-sm w-96 bg-white/90 dark:bg-black dark:text-white dark:shadow-lg dark:shadow-gray-200/10 flex justify-between px-4 border-gray-500 rounded-lg shadow-lg"
 >
-	<div class="flex w-full flex-col gap-y-4 py-4">
+	<div class="gap-y-4 flex flex-col w-full py-4">
 		<SearchField value={query} on:searchResults={handleSearchResults} />
 
 		{#if query}
-			<p class="text-sm text-gray-700 dark:text-gray-400">
+			<p class="dark:text-gray-400 text-sm text-gray-700">
 				Search results for "{query}".
-				<button type="button" on:click={clearResults} class="text-blue-600 hover:underline">
+				<button type="button" on:click={clearResults} class="hover:underline text-blue-600">
 					Clear results
 				</button>
 			</p>

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -102,15 +102,15 @@
 </script>
 
 <div
-	class="bg-blur-sm w-96 bg-white/90 dark:bg-black dark:text-white dark:shadow-lg dark:shadow-gray-200/10 flex justify-between px-4 border-gray-500 rounded-lg shadow-lg"
+	class="bg-blur-sm flex w-96 justify-between rounded-lg border-gray-500 bg-white/90 px-4 shadow-lg dark:bg-black dark:text-white dark:shadow-lg dark:shadow-gray-200/10"
 >
-	<div class="gap-y-4 flex flex-col w-full py-4">
+	<div class="flex w-full flex-col gap-y-4 py-4">
 		<SearchField value={query} on:searchResults={handleSearchResults} />
 
 		{#if query}
-			<p class="dark:text-gray-400 text-sm text-gray-700">
+			<p class="text-sm text-gray-700 dark:text-gray-400">
 				Search results for "{query}".
-				<button type="button" on:click={clearResults} class="hover:underline text-blue-600">
+				<button type="button" on:click={clearResults} class="text-blue-600 hover:underline">
 					Clear results
 				</button>
 			</p>


### PR DESCRIPTION
**Issue**
Earlier, the search icon hover was not visible and lacked color improvements. 

**Fixes**
-  Fixed the search icon color on hover.
- Added a shadow to the search box in dark mode.

**Screenshots**
![localhost_5173-GoogleChrome2024-10-2315-45-30-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/8ab83c68-8602-47f1-bb71-7bcb0d14eb36)
